### PR TITLE
Add template management for custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This project is a Streamlit application that generates image descriptions using 
 - Translate descriptions into multiple languages (currently supports English, Spanish, French, German, Italian, Japanese, and Chinese).
 - Approve and cache descriptions for future use.
 - Configure and generate output in a specified format.
+- Save and load custom templates as JSON.
+- Manage custom templates through a dedicated UI.
 
 ## Technologies Used
 
@@ -65,6 +67,13 @@ The Streamlit application provides a user-friendly interface for uploading image
 1. After generating the output, a preview section will display the generated output before finalizing it.
 2. Make adjustments to the configuration string and see the changes reflected in real-time.
 3. Download the generated output in different formats (e.g., JSON, YAML, text) using the provided download options.
+
+### Saving and Loading Custom Templates
+
+1. In the Streamlit app, navigate to the "Template Management" section in the sidebar.
+2. Enter a template name and content, then click "Save Template" to save the custom template.
+3. To load a saved template, select it from the dropdown menu and click "Load Template".
+4. To delete a saved template, select it from the dropdown menu and click "Delete Template".
 
 ## Contributing
 

--- a/src/image_description.py
+++ b/src/image_description.py
@@ -16,6 +16,8 @@ from transformers import BlipProcessor, BlipForConditionalGeneration
 from mistralai import Mistral
 from deepl import Translator
 import yaml
+import jsonschema
+from jsonschema import validate
 
 @dataclass
 class AppConfig:
@@ -37,6 +39,7 @@ class ImageDescriptionApp:
         self.processor, self.blip_model, self.mistral_client = self.load_models()
         self.load_approved_images()
         self.processed_images = []
+        self.custom_templates = self.load_custom_templates()
 
     def setup_logging(self):
         """Set up logging configuration."""
@@ -285,10 +288,93 @@ class ImageDescriptionApp:
             with open(prompt_file, 'w', encoding='utf-8') as f:
                 f.write(st.session_state.image_prompt)
 
+    def load_custom_templates(self):
+        """Load custom templates from a JSON file."""
+        templates_file = 'custom_templates.json'
+        if os.path.exists(templates_file):
+            try:
+                with open(templates_file, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, FileNotFoundError) as e:
+                self.logger.warning(
+                    "Error loading custom templates: %s. Starting with an empty list.",
+                    e
+                )
+                return []
+        else:
+            return []
+
+    def save_custom_templates(self):
+        """Save custom templates to a JSON file."""
+        templates_file = 'custom_templates.json'
+        try:
+            with open(templates_file, 'w', encoding='utf-8') as f:
+                json.dump(self.custom_templates, f, indent=4)
+            self.logger.info("Custom templates saved to %s", templates_file)
+        except Exception as e:
+            self.logger.error("Error saving custom templates: %s", e)
+
+    def validate_template(self, template: dict) -> bool:
+        """Validate a custom template against a JSON schema."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "template": {"type": "string"}
+            },
+            "required": ["name", "template"]
+        }
+        try:
+            validate(instance=template, schema=schema)
+            return True
+        except jsonschema.exceptions.ValidationError as e:
+            self.logger.error("Template validation error: %s", e)
+            return False
+
+    def render_template_management_ui(self):
+        """Render the UI for managing custom templates."""
+        st.sidebar.header("📝 Template Management")
+
+        template_name = st.sidebar.text_input("Template Name")
+        template_content = st.sidebar.text_area("Template Content")
+
+        if st.sidebar.button("Save Template"):
+            new_template = {"name": template_name, "template": template_content}
+            if self.validate_template(new_template):
+                self.custom_templates.append(new_template)
+                self.save_custom_templates()
+                st.sidebar.success("Template saved successfully!")
+            else:
+                st.sidebar.error("Invalid template format.")
+
+        if st.sidebar.button("Load Template"):
+            selected_template = st.sidebar.selectbox(
+                "Select a template to load:",
+                [template["name"] for template in self.custom_templates]
+            )
+            for template in self.custom_templates:
+                if template["name"] == selected_template:
+                    st.session_state.outputConfigurationValue = template["template"]
+                    st.sidebar.success("Template loaded successfully!")
+                    break
+
+        if st.sidebar.button("Delete Template"):
+            selected_template = st.sidebar.selectbox(
+                "Select a template to delete:",
+                [template["name"] for template in self.custom_templates]
+            )
+            self.custom_templates = [
+                template for template in self.custom_templates
+                if template["name"] != selected_template
+            ]
+            self.save_custom_templates()
+            st.sidebar.success("Template deleted successfully!")
+
     def run(self):
         """Run the Streamlit app."""
         # Render sidebar
         self.render_sidebar()
+        self.render_template_management_ui()
 
         if 'started' not in st.session_state:
             st.session_state.started = False

--- a/tests/test_image_description.py
+++ b/tests/test_image_description.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import json
-from src.image_description import describe_image_with_mistral, generate_title_and_description, load_blip_model, load_cached_images, save_approved_images
+from src.image_description import describe_image_with_mistral, generate_title_and_description, load_blip_model, load_cached_images, save_approved_images, ImageDescriptionApp, AppConfig
 from unittest.mock import patch, MagicMock
 import streamlit as st
 from streamlit.testing import TestRunner
@@ -102,6 +102,30 @@ class TestImageDescription(unittest.TestCase):
             self.assertIsNotNone(download_json_button)
             self.assertIsNotNone(download_yaml_button)
             self.assertIsNotNone(download_text_button)
+
+    def test_save_and_load_custom_templates(self):
+        config = AppConfig(mistral_api_key="test_key", deepl_auth_key="test_key")
+        app = ImageDescriptionApp(config)
+
+        # Test saving a custom template
+        template_name = "Test Template"
+        template_content = '{"key": "value"}'
+        app.custom_templates = []
+        app.save_custom_templates()
+        app.custom_templates.append({"name": template_name, "template": template_content})
+        app.save_custom_templates()
+
+        # Verify the template was saved
+        saved_templates = app.load_custom_templates()
+        self.assertEqual(len(saved_templates), 1)
+        self.assertEqual(saved_templates[0]["name"], template_name)
+        self.assertEqual(saved_templates[0]["template"], template_content)
+
+        # Test loading a custom template
+        loaded_templates = app.load_custom_templates()
+        self.assertEqual(len(loaded_templates), 1)
+        self.assertEqual(loaded_templates[0]["name"], template_name)
+        self.assertEqual(loaded_templates[0]["template"], template_content)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #9

Add functionality to save and load custom templates as JSON.

* **src/image_description.py**
  - Import `jsonschema` for template validation.
  - Add `load_custom_templates` and `save_custom_templates` methods to handle custom templates.
  - Add `validate_template` method to validate custom templates against a JSON schema.
  - Add `render_template_management_ui` method to provide UI for managing custom templates.
  - Update `run` method to render the template management UI.

* **README.md**
  - Update features list to include saving and loading custom templates.
  - Add instructions for saving and loading custom templates.

* **tests/test_image_description.py**
  - Import `ImageDescriptionApp` and `AppConfig`.
  - Add `test_save_and_load_custom_templates` method to test saving and loading custom templates.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/d-oit/blip_mistral_image_description_output/pull/10?shareId=9bde90bf-6194-4f7b-84a7-8560374ee729).